### PR TITLE
Fix:PlannerProject Entity 수정(confirmed_at)(#14)

### DIFF
--- a/backend/src/main/java/org/example/planlist/entity/PlannerProject.java
+++ b/backend/src/main/java/org/example/planlist/entity/PlannerProject.java
@@ -38,7 +38,7 @@ public class PlannerProject {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "confirmed_at", nullable = false)
+    @Column(name = "confirmed_at")
     private LocalDateTime confirmedAt;
 
     @Column(name = "start_date")


### PR DESCRIPTION
## 🔎 What is this PR?

- (백엔드) 관련 API 명세서 링크
https://www.notion.so/23bbc8a1c5e080228767d80dccb82c66?v=23bbc8a1c5e080c19dc1000cd2ac89b0&source=copy_link

## ✨ Changes
- PlannerProject 안에 confirmed_at을 중간 단계 말고 최종 프로젝트 저장시 값이 담기도록 nullable하게 바꿨습니다.

## 📷 Result

- 스크린샷, 시연 영상

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
