### PR TITLE
Feat/#19 travel

### DIFF
--- a/backend/src/main/java/org/example/planlist/controller/DatePlannerController.java
+++ b/backend/src/main/java/org/example/planlist/controller/DatePlannerController.java
@@ -1,0 +1,81 @@
+package org.example.planlist.controller;
+
+import org.example.planlist.dto.DatePlannerDTO.DatePlannerRequestDTO;
+import org.example.planlist.dto.DatePlannerDTO.DatePlannerResponseDTO;
+import org.example.planlist.entity.Wishlist;
+import org.example.planlist.repository.WishlistRepository;
+import org.example.planlist.service.DatePlannerService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/planner/{projectId}/travel/dateplanner")
+public class DatePlannerController {
+    private final DatePlannerService datePlannerService;
+    private final WishlistRepository wishlistRepository;
+
+    public DatePlannerController(DatePlannerService datePlannerService, WishlistRepository wishlistRepository) {
+        this.datePlannerService = datePlannerService;
+        this.wishlistRepository = wishlistRepository;
+    }
+
+    @GetMapping("/wishlist")
+    public ResponseEntity<List<DatePlannerResponseDTO>> getWishlistItems(
+            @PathVariable Long projectId,
+            @RequestParam String category) {
+
+        // String → Enum 변환 (대소문자 무시)
+        Wishlist.Category categoryEnum = Arrays.stream(Wishlist.Category.values())
+                .filter(c -> c.name().equalsIgnoreCase(category))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 카테고리 값: " + category));
+
+        // Entity → DTO 변환
+        List<DatePlannerResponseDTO> items = wishlistRepository
+                .findByProject_ProjectIdAndCategory(projectId, categoryEnum)
+                .stream()
+                .map(w -> DatePlannerResponseDTO.builder()
+                        .wishlistId(w.getWishlistId())
+                        .wishlistName(w.getName())
+                        .category(w.getCategory().name())
+                        .address(w.getAddress())
+                        .latitude(w.getLatitude())
+                        .longitude(w.getLongitude())
+                        .memo(w.getMemo())
+                        .cost(w.getCost())
+                        .createdAt(w.getCreatedAt())
+                        .build())
+                .toList();
+
+        return ResponseEntity.ok(items);
+    }
+
+    @PostMapping("")
+    public ResponseEntity<String> addDatePlannerItem(@PathVariable Long projectId,
+                                                     @RequestBody DatePlannerRequestDTO requestDTO) {
+        datePlannerService.addItem(projectId, requestDTO.getCategory(), requestDTO);
+        return ResponseEntity.ok("해당 날짜의 플래너에 항목이 추가되었습니다.");
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<DatePlannerResponseDTO>> getDatePlannerItems(
+            @PathVariable Long projectId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        List<DatePlannerResponseDTO> items = datePlannerService.getDatePlannerItems(projectId, date);
+        return ResponseEntity.ok(items);
+    }
+
+
+    @DeleteMapping("/{datePlannerId}")
+    public ResponseEntity<String> deleteDatePlannerItem(@PathVariable Long datePlannerId) {
+        datePlannerService.deleteItem(datePlannerId);
+        return ResponseEntity.ok("해당 날짜의 항목이 삭제되었습니다.");
+    }
+}
+

--- a/backend/src/main/java/org/example/planlist/controller/MoveBetweenPlacesController.java
+++ b/backend/src/main/java/org/example/planlist/controller/MoveBetweenPlacesController.java
@@ -1,0 +1,54 @@
+package org.example.planlist.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.planlist.dto.MoveBetweenPlacesDTO.MoveBetweenPlacesRequestDTO;
+import org.example.planlist.dto.MoveBetweenPlacesDTO.MoveBetweenPlacesResponseDTO;
+import org.example.planlist.service.MoveBetweenPlacesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/planner/{projectId}/travel/dateplanner")
+@RequiredArgsConstructor
+public class MoveBetweenPlacesController {
+
+    private final MoveBetweenPlacesService moveBetweenPlacesService;
+
+    // 이동수단 추가
+    @PostMapping("/{datePlannerId}/transport")
+    public ResponseEntity<Void> addTransportation(
+            @PathVariable Long projectId,
+            @PathVariable Long datePlannerId,
+            @RequestBody @Valid MoveBetweenPlacesRequestDTO dto) {
+
+        moveBetweenPlacesService.addTransportation(projectId, datePlannerId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 날짜별 플래너 기준 이동수단 조회
+    @GetMapping("/{datePlannerId}/transport")
+    public ResponseEntity<List<MoveBetweenPlacesResponseDTO>> getTransportationsByDatePlanner(
+            @PathVariable Long projectId,
+            @PathVariable Long datePlannerId) {
+
+        return ResponseEntity.ok(moveBetweenPlacesService.getTransportationsByDatePlanner(datePlannerId));
+    }
+
+    // 프로젝트 전체 이동수단 조회
+    @GetMapping("/transport")
+    public ResponseEntity<List<MoveBetweenPlacesResponseDTO>> getTransportationsByProject(
+            @PathVariable Long projectId) {
+
+        return ResponseEntity.ok(moveBetweenPlacesService.getTransportationsByProject(projectId));
+    }
+
+    @DeleteMapping("/transport/{moveId}")
+    public ResponseEntity<Void> deleteTransportation(@PathVariable Long moveId) {
+        moveBetweenPlacesService.deleteTransportation(moveId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/backend/src/main/java/org/example/planlist/controller/PlannerProjectController.java
+++ b/backend/src/main/java/org/example/planlist/controller/PlannerProjectController.java
@@ -90,7 +90,17 @@ public class PlannerProjectController {
         return ResponseEntity.ok().build();
     }
 
-    // 8. 프로젝트 최종 확정
+    // 8. 끝 날짜 설정
+    @PostMapping("/{projectId}/end-date")
+    public ResponseEntity<Void> setEndDate(
+            @PathVariable Long projectId,
+            @RequestParam String endDate // "yyyy-MM-dd" 형태로 넘어오도록
+    ) {
+        plannerProjectService.setEndDate(projectId, LocalDate.parse(endDate));
+        return ResponseEntity.ok().build();
+    }
+
+    // 9. 프로젝트 최종 확정
     @PostMapping("/{projectId}/finalize")
     public ResponseEntity<Void> finalizeProject(@PathVariable Long projectId) {
         plannerProjectService.finalizeProject(projectId);

--- a/backend/src/main/java/org/example/planlist/controller/WishlistController.java
+++ b/backend/src/main/java/org/example/planlist/controller/WishlistController.java
@@ -14,7 +14,7 @@ public class WishlistController {
         this.wishlistService = wishlistService;
     }
 
-    // 카테고리 선택, 경로에서 projectId 가져옴
+    // 카테고리 선택, url 경로에서 projectId 가져옴
     @PostMapping("")
     public ResponseEntity<String> addWishlistItem(@PathVariable Long projectId,
                                                   @RequestBody WishlistRequestDTO requestDTO) {

--- a/backend/src/main/java/org/example/planlist/controller/WishlistController.java
+++ b/backend/src/main/java/org/example/planlist/controller/WishlistController.java
@@ -1,9 +1,13 @@
 package org.example.planlist.controller;
 
 import org.example.planlist.dto.WishlistDTO.WishlistRequestDTO;
+import org.example.planlist.dto.WishlistDTO.WishlistResponseDTO;
+import org.example.planlist.entity.Wishlist;
 import org.example.planlist.service.WishlistService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/planner/{projectId}/travel/wishlist")
@@ -21,6 +25,18 @@ public class WishlistController {
         wishlistService.addItem(projectId, requestDTO.getCategory(), requestDTO);
         return ResponseEntity.ok(" 카테고리에 항목이 추가되었습니다.");
     }
+
+    @GetMapping("")
+    public ResponseEntity<List<WishlistResponseDTO>> getWishlistByCategory(
+            @PathVariable Long projectId,
+            @RequestParam String category
+    ) {
+        List<WishlistResponseDTO> items = wishlistService.getItems(projectId, category);
+        return ResponseEntity.ok(items);
+    }
+
+
+
 
     @DeleteMapping("/{wishlistId}")
     public ResponseEntity<String> deleteWishlistItem(@PathVariable Long wishlistId) {

--- a/backend/src/main/java/org/example/planlist/dto/DatePlannerDTO/DatePlannerRequestDTO.java
+++ b/backend/src/main/java/org/example/planlist/dto/DatePlannerDTO/DatePlannerRequestDTO.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class DatePlannerRequestDTO {
+
     @NotNull(message = "날짜를 선택해주세요.")
     private LocalDate date;
 
@@ -24,7 +25,14 @@ public class DatePlannerRequestDTO {
     private Float latitude;
     private Float longitude;
     private LocalDateTime visitTime;
-    private LocalDateTime createdAt;
-    private Long projectId;
+
+    // createdAt은 서버에서 @PrePersist로 자동 설정되므로 요청 DTO에는 불필요
+    // private LocalDateTime createdAt;
+
+    // projectId는 이미 @PathVariable로 받는 경우가 많아서 request body에는 보통 불필요
+    // private Long projectId;
+
     private Long wishlistId;
+    private Long inviteeId; // participantId로 명확히 변경 가능
 }
+

--- a/backend/src/main/java/org/example/planlist/dto/DatePlannerDTO/DatePlannerResponseDTO.java
+++ b/backend/src/main/java/org/example/planlist/dto/DatePlannerDTO/DatePlannerResponseDTO.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class DatePlannerResponseDTO {
+    private Long calendarId;
     private LocalDate date;
     private String category;
     private String memo;
@@ -20,6 +21,12 @@ public class DatePlannerResponseDTO {
     private Float longitude;
     private LocalDateTime visitTime;
     private LocalDateTime createdAt;
+
     private Long projectId;
     private Long wishlistId;
+    private String wishlistName;
+
+    // 필요하면 참가자 정보도 간단히 추가 가능
+    // private Long participantId;
 }
+

--- a/backend/src/main/java/org/example/planlist/entity/DatePlanner.java
+++ b/backend/src/main/java/org/example/planlist/entity/DatePlanner.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -64,6 +66,13 @@ public class DatePlanner {
     private PlannerProject project;
 
     @ManyToOne
+    @JoinColumn(name = "invitee_id")
+    private ProjectParticipant participant;
+
+    @ManyToOne
     @JoinColumn(name = "wishlist_id")
     private Wishlist wishlist;
+
+    @OneToMany(mappedBy = "datePlanner", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MoveBetweenPlaces> moveBetweenPlacesList = new ArrayList<>();
 }

--- a/backend/src/main/java/org/example/planlist/entity/MoveBetweenPlaces.java
+++ b/backend/src/main/java/org/example/planlist/entity/MoveBetweenPlaces.java
@@ -31,7 +31,7 @@ public class MoveBetweenPlaces {
 
     @ManyToOne
     @JoinColumn(name = "calendar_id")
-    private ParticipantAvailability availability;
+    private DatePlanner datePlanner;
 
     @ManyToOne
     @JoinColumn(name = "project_id")

--- a/backend/src/main/java/org/example/planlist/entity/PlannerProject.java
+++ b/backend/src/main/java/org/example/planlist/entity/PlannerProject.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -78,4 +79,13 @@ public class PlannerProject {
             confirmedAt = LocalDateTime.now();
         }
     }
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DatePlanner> datePlanners = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Wishlist> wishlists = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MoveBetweenPlaces> moveBetweenPlacesList = new ArrayList<>();
 }

--- a/backend/src/main/java/org/example/planlist/entity/Wishlist.java
+++ b/backend/src/main/java/org/example/planlist/entity/Wishlist.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -63,6 +65,9 @@ public class Wishlist {
     @ManyToOne
     @JoinColumn(name = "project_id")
     private PlannerProject project;
+
+    @OneToMany(mappedBy = "wishlist", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DatePlanner> datePlanners = new ArrayList<>();
 }
 
 

--- a/backend/src/main/java/org/example/planlist/repository/DatePlannerRepository.java
+++ b/backend/src/main/java/org/example/planlist/repository/DatePlannerRepository.java
@@ -1,0 +1,22 @@
+package org.example.planlist.repository;
+
+import org.example.planlist.entity.DatePlanner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DatePlannerRepository extends JpaRepository<DatePlanner, Long> {
+    boolean existsByProject_ProjectIdAndCategoryAndWishlist_WishlistId(
+            Long projectId, DatePlanner.Category category, Long wishlistId
+    );
+
+    List<DatePlanner> findByProject_ProjectIdAndDateAndCategory(
+            Long projectId,
+            LocalDate date,
+            DatePlanner.Category category
+    );
+
+    List<DatePlanner> findByProject_ProjectIdAndDate(Long projectId, LocalDate date);
+
+}

--- a/backend/src/main/java/org/example/planlist/repository/MoveBetweenPlacesRepository.java
+++ b/backend/src/main/java/org/example/planlist/repository/MoveBetweenPlacesRepository.java
@@ -1,0 +1,11 @@
+package org.example.planlist.repository;
+
+import org.example.planlist.entity.MoveBetweenPlaces;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MoveBetweenPlacesRepository extends JpaRepository<MoveBetweenPlaces, Long> {
+    List<MoveBetweenPlaces> findByDatePlanner_CalendarId(Long calendarId);
+    List<MoveBetweenPlaces> findByProject_ProjectId(Long projectId);
+}

--- a/backend/src/main/java/org/example/planlist/repository/WishlistRepository.java
+++ b/backend/src/main/java/org/example/planlist/repository/WishlistRepository.java
@@ -3,9 +3,13 @@ package org.example.planlist.repository;
 import org.example.planlist.entity.Wishlist;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
     // 프로젝트 + 카테고리 + 이름 중복 체크
     boolean existsByProject_ProjectIdAndCategoryAndName(Long projectId,
                                                  Wishlist.Category category,
                                                  String name);
+    List<Wishlist> findByProject_ProjectIdAndCategory(Long projectId, Wishlist.Category category);
+
 }

--- a/backend/src/main/java/org/example/planlist/service/DatePlannerService.java
+++ b/backend/src/main/java/org/example/planlist/service/DatePlannerService.java
@@ -1,0 +1,140 @@
+package org.example.planlist.service;
+
+import jakarta.persistence.*;
+import jakarta.transaction.Transactional;
+import org.example.planlist.dto.DatePlannerDTO.DatePlannerRequestDTO;
+import org.example.planlist.dto.DatePlannerDTO.DatePlannerResponseDTO;
+import org.example.planlist.entity.DatePlanner;
+import org.example.planlist.entity.PlannerProject;
+import org.example.planlist.entity.ProjectParticipant;
+import org.example.planlist.entity.Wishlist;
+import org.example.planlist.repository.DatePlannerRepository;
+import org.example.planlist.repository.PlannerProjectRepository;
+import org.example.planlist.repository.ProjectParticipantRepository;
+import org.example.planlist.repository.WishlistRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class DatePlannerService {
+    private final DatePlannerRepository datePlannerRepository;
+    private final PlannerProjectRepository plannerProjectRepository;
+    private final ProjectParticipantRepository projectParticipantRepository;
+    private final WishlistRepository wishlistRepository;
+
+    public DatePlannerService(DatePlannerRepository datePlannerRepository,
+                              PlannerProjectRepository plannerProjectRepository,
+                              ProjectParticipantRepository projectParticipantRepository,
+                              WishlistRepository wishlistRepository) {
+        this.datePlannerRepository = datePlannerRepository;
+        this.plannerProjectRepository = plannerProjectRepository;
+        this.projectParticipantRepository = projectParticipantRepository;
+        this.wishlistRepository = wishlistRepository;
+    }
+
+    public List<DatePlannerResponseDTO> getItemsByDateAndCategory(Long projectId, LocalDate date, String categoryStr) {
+        DatePlanner.Category category = Arrays.stream(DatePlanner.Category.values())
+                .filter(c -> c.name().equalsIgnoreCase(categoryStr))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 카테고리 값입니다: " + categoryStr));
+
+        return datePlannerRepository.findByProject_ProjectIdAndDateAndCategory(projectId, date, category)
+                .stream()
+                .map(dp -> DatePlannerResponseDTO.builder()
+                        .calendarId(dp.getCalendarId())
+                        .date(dp.getDate())
+                        .category(dp.getCategory().name())
+                        .memo(dp.getMemo())
+                        .cost(dp.getCost())
+                        .address(dp.getAddress())
+                        .latitude(dp.getLatitude())
+                        .longitude(dp.getLongitude())
+                        .visitTime(dp.getVisitTime())
+                        .wishlistName(dp.getWishlist() != null ? dp.getWishlist().getName() : null)
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public void addItem(Long projectId, String categoryStr, DatePlannerRequestDTO dto) {
+        // 1) 프로젝트 존재 체크
+        PlannerProject project = plannerProjectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 프로젝트입니다."));
+
+        // 2) 참여자 조회
+        ProjectParticipant participant = projectParticipantRepository
+                .findByIdAndProject_ProjectId(dto.getInviteeId(), projectId)
+                .orElseThrow(() -> new EntityNotFoundException("프로젝트 참여자가 아닙니다."));
+
+        // 3) 날짜 체크
+        if (dto.getDate() == null) {
+            throw new IllegalArgumentException("여행 프로젝트 날짜를 선택해주세요.");
+        }
+
+        // 4) 카테고리 변환
+        DatePlanner.Category category = Arrays.stream(DatePlanner.Category.values())
+                .filter(c -> c.name().equalsIgnoreCase(categoryStr))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 카테고리 값입니다: " + categoryStr));
+
+        // 5) Wishlist 조회
+        Wishlist wishlist = wishlistRepository.findById(dto.getWishlistId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 위시리스트 항목이 없습니다."));
+
+        // 6) 중복 검사: 프로젝트 + 카테고리 + 위시리스트 ID
+        if (datePlannerRepository.existsByProject_ProjectIdAndCategoryAndWishlist_WishlistId(
+                projectId, category, wishlist.getWishlistId())) {
+            throw new IllegalStateException("이미 존재하는 항목입니다.");
+        }
+
+        // 7) 저장
+        DatePlanner datePlanner = DatePlanner.builder()
+                .date(dto.getDate())
+                .category(category)
+                .memo(dto.getMemo())
+                .cost(dto.getCost())
+                .address(dto.getAddress())
+                .latitude(dto.getLatitude())
+                .longitude(dto.getLongitude())
+                .visitTime(dto.getVisitTime())
+                .project(project)
+                .participant(participant)
+                .wishlist(wishlist)
+                .build();
+
+        datePlannerRepository.save(datePlanner);
+    }
+
+    @Transactional
+    public List<DatePlannerResponseDTO> getDatePlannerItems(Long projectId, LocalDate date) {
+        return datePlannerRepository.findByProject_ProjectIdAndDate(projectId, date)
+                .stream()
+                .map(dp -> DatePlannerResponseDTO.builder()
+                        .calendarId(dp.getCalendarId())
+                        .date(dp.getDate())
+                        .category(dp.getCategory().name())
+                        .memo(dp.getMemo())
+                        .cost(dp.getCost())
+                        .address(dp.getAddress())
+                        .latitude(dp.getLatitude())
+                        .longitude(dp.getLongitude())
+                        .visitTime(dp.getVisitTime())
+                        .createdAt(dp.getCreatedAt())
+                        .projectId(projectId)
+                        .wishlistId(dp.getWishlist() != null ? dp.getWishlist().getWishlistId() : null)
+                        .wishlistName(dp.getWishlist() != null ? dp.getWishlist().getName() : null)
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public void deleteItem(Long calendarId) {
+        if (!datePlannerRepository.existsById(calendarId)) {
+            throw new EntityNotFoundException("해당 날짜에 삭제할 항목이 없습니다.");
+        }
+        datePlannerRepository.deleteById(calendarId);
+    }
+}

--- a/backend/src/main/java/org/example/planlist/service/MoveBetweenPlacesService.java
+++ b/backend/src/main/java/org/example/planlist/service/MoveBetweenPlacesService.java
@@ -1,0 +1,76 @@
+package org.example.planlist.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.example.planlist.dto.MoveBetweenPlacesDTO.MoveBetweenPlacesRequestDTO;
+import org.example.planlist.dto.MoveBetweenPlacesDTO.MoveBetweenPlacesResponseDTO;
+import org.example.planlist.entity.DatePlanner;
+import org.example.planlist.entity.MoveBetweenPlaces;
+import org.example.planlist.entity.PlannerProject;
+import org.example.planlist.repository.DatePlannerRepository;
+import org.example.planlist.repository.MoveBetweenPlacesRepository;
+import org.example.planlist.repository.PlannerProjectRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MoveBetweenPlacesService {
+
+    private final MoveBetweenPlacesRepository moveBetweenPlacesRepository;
+    private final DatePlannerRepository datePlannerRepository;
+    private final PlannerProjectRepository plannerProjectRepository;
+
+    @Transactional
+    public void addTransportation(Long projectId, Long datePlannerId, MoveBetweenPlacesRequestDTO dto) {
+        PlannerProject project = plannerProjectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 프로젝트가 없습니다."));
+
+        DatePlanner datePlanner = datePlannerRepository.findById(datePlannerId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 날짜별 플래너 항목이 없습니다."));
+
+        MoveBetweenPlaces move = MoveBetweenPlaces.builder()
+                .transportation(dto.getTransportation())
+                .durationMin(dto.getDurationMin())
+                .travelDate(dto.getTravelDate())
+                .datePlanner(datePlanner)
+                .project(project)
+                .build();
+
+        moveBetweenPlacesRepository.save(move);
+    }
+
+    @Transactional
+    public List<MoveBetweenPlacesResponseDTO> getTransportationsByDatePlanner(Long datePlannerId) {
+        return moveBetweenPlacesRepository.findByDatePlanner_CalendarId(datePlannerId)
+                .stream()
+                .map(e -> MoveBetweenPlacesResponseDTO.builder()
+                        .transportation(e.getTransportation())
+                        .durationMin(e.getDurationMin())
+                        .travelDate(e.getTravelDate())
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public List<MoveBetweenPlacesResponseDTO> getTransportationsByProject(Long projectId) {
+        return moveBetweenPlacesRepository.findByProject_ProjectId(projectId)
+                .stream()
+                .map(e -> MoveBetweenPlacesResponseDTO.builder()
+                        .transportation(e.getTransportation())
+                        .durationMin(e.getDurationMin())
+                        .travelDate(e.getTravelDate())
+                        .build())
+                .toList();
+    }
+
+    // 이동수단 삭제
+    public void deleteTransportation(Long moveId) {
+        MoveBetweenPlaces move = moveBetweenPlacesRepository.findById(moveId)
+                .orElseThrow(() -> new EntityNotFoundException("이동수단 항목을 찾을 수 없습니다. ID: " + moveId));
+
+        moveBetweenPlacesRepository.delete(move);
+    }
+}

--- a/backend/src/main/java/org/example/planlist/service/PlannerProjectService.java
+++ b/backend/src/main/java/org/example/planlist/service/PlannerProjectService.java
@@ -89,6 +89,14 @@ public class PlannerProjectService {
         project.setStartDate(startDate);
     }
 
+    // 7. 종료 날짜 설정
+    @Transactional
+    public void setEndDate(Long projectId, LocalDate endDate) {
+        PlannerProject project = plannerProjectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException("프로젝트를 찾을 수 없습니다."));
+        project.setEndDate(endDate);
+    }
+
     // 8. 프로젝트 최종 확정
     @Transactional
     public void finalizeProject(Long projectId) {

--- a/backend/src/main/java/org/example/planlist/service/WishlistService.java
+++ b/backend/src/main/java/org/example/planlist/service/WishlistService.java
@@ -25,8 +25,6 @@ public class WishlistService {
 
     @Transactional
     public void addItem(Long projectId, String categoryStr, WishlistRequestDTO dto) {
-        System.out.println("addItem 호출됨 - inviteeId: " + dto.getInviteeId() + ", projectId: " + projectId);
-
         // 1) 프로젝트 존재 체크
         PlannerProject project = plannerProjectRepository.findById(projectId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 프로젝트입니다."));
@@ -34,7 +32,7 @@ public class WishlistService {
         // 2) 참여자 조회 (inviteeId = ProjectParticipant PK)
         ProjectParticipant participant = projectParticipantRepository
                 .findByIdAndProject_ProjectId(dto.getInviteeId(), projectId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 프로젝트의 참여자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("프로젝트 참여자가 아닙니다."));
 
 
         // 3) 카테고리 변환 (대소문자 무시)

--- a/backend/src/main/java/org/example/planlist/service/WishlistService.java
+++ b/backend/src/main/java/org/example/planlist/service/WishlistService.java
@@ -3,11 +3,14 @@ package org.example.planlist.service;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import org.example.planlist.dto.WishlistDTO.WishlistRequestDTO;
+import org.example.planlist.dto.WishlistDTO.WishlistResponseDTO;
 import org.example.planlist.entity.*;
 import org.example.planlist.repository.PlannerProjectRepository;
 import org.example.planlist.repository.ProjectParticipantRepository;
 import org.example.planlist.repository.WishlistRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class WishlistService {
@@ -61,6 +64,37 @@ public class WishlistService {
 
         wishlistRepository.save(wishlist);
     }
+
+    @Transactional
+    public List<WishlistResponseDTO> getItems(Long projectId, String categoryStr) {
+        // 1) 프로젝트 존재 체크
+        plannerProjectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 프로젝트입니다."));
+
+        // 2) 카테고리 변환
+        Wishlist.Category category = java.util.Arrays.stream(Wishlist.Category.values())
+                .filter(c -> c.name().equalsIgnoreCase(categoryStr))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 카테고리 값입니다: " + categoryStr));
+
+        // 3) 조회 + DTO 변환
+        return wishlistRepository.findByProject_ProjectIdAndCategory(projectId, category)
+                .stream()
+                .map(w -> WishlistResponseDTO.builder()
+                        .name(w.getName())
+                        .address(w.getAddress())
+                        .latitude(w.getLatitude())
+                        .longitude(w.getLongitude())
+                        .category(w.getCategory().name())
+                        .memo(w.getMemo())
+                        .cost(w.getCost())
+                        .projectId(w.getProject().getProjectId())
+                        .inviteeId(w.getParticipant().getId())
+                        .build())
+                .toList();
+    }
+
+
 
     @Transactional
     public void deleteItem(Long wishlistId) {


### PR DESCRIPTION
## 🔎 What is this PR?

- (프론트엔드) 관련 와이어프레임 또는 프로토타입 이미지
- (백엔드) 관련 API 명세서 링크

## ✨ Changes

- 날짜별 플래너 구현
> 추가, 삭제, 조회
- 이동수단/시간 구현
> 추가, 삭제, 조회 
- 엔티티 외래키 수정
> 양방향 설정 안 했더니 삭제가 엉켜서 수정했습니다.
- 플래너 프로젝트 끝 날짜 설정 구현
> 시작 날짜 설정만 되어 있어서 추가했습니다.

## 📷 Result

- 스크린샷, 시연 영상

## 💬 To. Reviewer

DatePlanner의 pk 명이 calendarId로 되어 있으니 유의해주세요.