### PR TITLE
feat : PT_userInvite

### DIFF
--- a/backend/src/main/java/org/example/planlist/controller/Pt/PtController.java
+++ b/backend/src/main/java/org/example/planlist/controller/Pt/PtController.java
@@ -2,6 +2,7 @@ package org.example.planlist.controller.Pt;
 
 import lombok.RequiredArgsConstructor;
 import org.example.planlist.dto.PT.request.PtProjectCreateRequestDTO;
+import org.example.planlist.dto.PT.request.PtProjectInviteRequestDTO;
 import org.example.planlist.dto.PT.response.InviteUserResponseDTO;
 import org.example.planlist.dto.PT.response.PtProjectCreateResponseDTO;
 import org.example.planlist.security.CustomUserDetails;
@@ -28,12 +29,36 @@ public class PtController {
     }
 
     @GetMapping("/inviteUser/{projectId}")
-    public ResponseEntity<InviteUserResponseDTO> inviteUser(
+    public ResponseEntity<InviteUserResponseDTO> inviteUserPage(
             @PathVariable Long projectId) {
 
         InviteUserResponseDTO response = ptService.getInviteUsers(projectId);
 
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/inviteUser/{projectId}/invite")
+    public ResponseEntity<String> inviteUser(
+            @PathVariable Long projectId,
+            @RequestBody PtProjectInviteRequestDTO request) {
+
+        ptService.sendPtInvite(projectId, request);
+
+        return ResponseEntity.ok("프로젝트 요청 성공!");
+    }
+
+    @DeleteMapping("/inviteUser/{projectId}/deleteRequest/{participantId}")
+    public ResponseEntity<String> acceptInvite(
+            @PathVariable Long projectId,
+            @PathVariable Long participantId
+    ){
+
+        ptService.deletePtInvite(projectId, participantId);
+
+        return ResponseEntity.ok("프로젝트 요청 삭제 성공!");
+
+    }
+
+
 }
 

--- a/backend/src/main/java/org/example/planlist/dto/PT/request/PtProjectInviteDeleteRequestDTO.java
+++ b/backend/src/main/java/org/example/planlist/dto/PT/request/PtProjectInviteDeleteRequestDTO.java
@@ -1,0 +1,8 @@
+package org.example.planlist.dto.PT.request;
+
+import lombok.Data;
+
+@Data
+public class PtProjectInviteDeleteRequestDTO {
+    private String email;
+}

--- a/backend/src/main/java/org/example/planlist/dto/PT/request/PtProjectInviteRequestDTO.java
+++ b/backend/src/main/java/org/example/planlist/dto/PT/request/PtProjectInviteRequestDTO.java
@@ -1,0 +1,10 @@
+package org.example.planlist.dto.PT.request;
+
+import lombok.Data;
+import org.example.planlist.entity.ProjectParticipant;
+
+@Data
+public class PtProjectInviteRequestDTO {
+    private String email;
+    private ProjectParticipant.Role role;
+}

--- a/backend/src/main/java/org/example/planlist/dto/PT/response/InviteUserResponseDTO.java
+++ b/backend/src/main/java/org/example/planlist/dto/PT/response/InviteUserResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.example.planlist.entity.PlannerProject;
 import org.example.planlist.entity.ProjectParticipant;
+import org.example.planlist.entity.User;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ public class InviteUserResponseDTO {
     @Data
     @AllArgsConstructor
     public static class ParticipantDTO {
+        private Long userId;
         private String name;
         private ProjectParticipant.Role role;      // TRAINER / TRAINEE
         private String profileImage;

--- a/backend/src/main/java/org/example/planlist/repository/PlannerProjectRepository.java
+++ b/backend/src/main/java/org/example/planlist/repository/PlannerProjectRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Repository
 public interface PlannerProjectRepository extends JpaRepository<PlannerProject, Long> {
 
-    Optional<PlannerProject> findById(Long projectId);
+    PlannerProject findByProjectId(Long projectId);
 
     List<PlannerProject> findByCreatorAndStatus(User user, PlannerProject.Status status);
 

--- a/backend/src/main/java/org/example/planlist/repository/ProjectParticipantRepository.java
+++ b/backend/src/main/java/org/example/planlist/repository/ProjectParticipantRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public interface ProjectParticipantRepository extends JpaRepository<ProjectParticipant, Long> {
     List<ProjectParticipant> findByUser(User user);
 
-    Optional<ProjectParticipant> findById(Long id);
+    ProjectParticipant findByProject_ProjectIdAndUserId(Long ProjectId, Long UserId);
 
 //    Optional<ProjectParticipant> findByUserId(Long userId);
 
@@ -31,6 +31,7 @@ public interface ProjectParticipantRepository extends JpaRepository<ProjectParti
 
     Optional<ProjectParticipant> findByIdAndProject_ProjectId(Long participantId, Long projectId);
 
+//    boolean existsByProjectIdAndUser(Long projectId, User user);
 
 //import org.example.planlist.dto.ProjectParticipantDTO.ProjectParticipantRequestDTO;
 //import org.example.planlist.entity.PlannerProject;

--- a/backend/src/main/java/org/example/planlist/service/PT/PtService.java
+++ b/backend/src/main/java/org/example/planlist/service/PT/PtService.java
@@ -1,14 +1,13 @@
 package org.example.planlist.service.PT;
 
 import lombok.RequiredArgsConstructor;
+import org.example.planlist.dto.FriendDTO.request.RequestSendRequestDTO;
 import org.example.planlist.dto.PT.request.PtProjectCreateRequestDTO;
+import org.example.planlist.dto.PT.request.PtProjectInviteRequestDTO;
 import org.example.planlist.dto.PT.response.InviteUserResponseDTO;
 import org.example.planlist.dto.PT.response.PtProjectCreateResponseDTO;
 import org.example.planlist.dto.ProjectParticipantDTO.ProjectParticipantRequestDTO;
-import org.example.planlist.entity.PlannerProject;
-import org.example.planlist.entity.ProjectParticipant;
-import org.example.planlist.entity.PtSession;
-import org.example.planlist.entity.User;
+import org.example.planlist.entity.*;
 import org.example.planlist.repository.*;
 import org.example.planlist.security.SecurityUtil;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,6 +29,8 @@ public class PtService {
     private final ProjectParticipantRepository participantRepository;
     private final PtSessionRepository ptSessionRepository;
     private final FriendRepository friendRepository; // 친구 관계 조회용
+
+    public Optional<User> findByEmail(String email) {return userRepository.findByEmail(email);}
 
     @Transactional
     public PtProjectCreateResponseDTO createProject(PtProjectCreateRequestDTO request) {
@@ -98,6 +100,7 @@ public class PtService {
 
         List<InviteUserResponseDTO.ParticipantDTO> participantsDto = participants.stream()
                 .map(p -> new InviteUserResponseDTO.ParticipantDTO(
+                        p.getUser().getId(),
                         p.getUser().getName(),
                         p.getRole(),
                         p.getUser().getProfileImage(),
@@ -112,4 +115,41 @@ public class PtService {
 
         return response;
     }
+
+    @Transactional
+    public void sendPtInvite(Long projectId, PtProjectInviteRequestDTO ptProjectInviteRequestDTO) {
+
+        String email = ptProjectInviteRequestDTO.getEmail();
+        User receiver = findByEmail(email).orElseThrow(() ->
+                new IllegalArgumentException("해당 이메일의 사용자가 없습니다."));
+        User creater = SecurityUtil.getCurrentUser();
+        ProjectParticipant.Role role = ptProjectInviteRequestDTO.getRole();
+
+        PlannerProject project = projectRepository.findByProjectId(projectId);
+
+        // 🔒 이미 요청이 존재하는지 확인
+        if (participantRepository.existsByProjectAndUser(project, receiver)) {
+            throw new IllegalStateException("이미 해당 사용자에게 초대 요청을 보냈습니다.");
+        }
+
+
+        ProjectParticipant participant = ProjectParticipant.builder()
+                .user(receiver)
+                .project(project)
+                .response(ProjectParticipant.Response.WAITING)
+                .role(role)
+//                .message(requestSendRequestDTO.getMessage()) // 필요하다면
+                .build();
+
+        participantRepository.save(participant);
+    }
+
+    @Transactional
+    public void deletePtInvite(Long projectId, Long participantId) {
+        ProjectParticipant participant = participantRepository.findByProject_ProjectIdAndUserId(projectId, participantId);
+
+        participantRepository.delete(participant);
+    }
+
+
 }


### PR DESCRIPTION
## 🔎 What is this PR?

- /api/pt/inviteUser/{projectId}/invite : 유저 초대
- /api/pt/inviteUser/{projectId}/deleteRequest/{participantId} : 유저 초대 삭제

## ✨ Changes

- 해당 두 기능 구현
- 유저 초대 페이지 컨트롤러 함수명 변경
- 유저 초대 페이지에 참가자의 userId도 전달하게끔 변경

## 📷 Result

- 스크린샷, 시연 영상

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
